### PR TITLE
feat: add H.264 (AVC) codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | VP8   | ✅    | ✅       |
 | VP9   | ✅    | ✅       |
 | AV1   | ✅    | ✅       |
-| H.264 | ⬜    | ⬜       |
-| H.265 | ⬜    | ⬜       |
+| H.264 (AVC) | ✅ | ✅   |
+| H.265 (HEVC) | ⬜ | ⬜  |
+| H.266 (VVC) | ⬜ | ⬜   |
 
 ## Install
 
@@ -73,12 +74,28 @@ console.log(info.toHumanReadable());
 // { profile: 'main', level: '5.1', tier: 'main', bitDepth: '8', ... }
 ```
 
+### H.264 / AVC
+
+The AVC codec string encodes `profile_idc`, the constraint-set flags, and `level_idc` as three
+hex bytes. Fields are exposed as raw bytes and decoded in `toHumanReadable()`.
+
+```ts
+import { h264 } from '@irbisadm/iso-codec-string';
+
+const info = h264.H264Info.fromString('avc1.640028');
+console.log(info.toHumanReadable().profile); // 'High'
+console.log(info.toHumanReadable().level);   // '4.0'
+console.log(info.toString());                // 'avc1.640028'
+```
+
 ## API
 
-- `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`) and
-  returns a `Vp8Info`, `Vp9Info`, or `Av1Info`. Throws `Unknown codec` for anything else.
+- `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
+  `avc1`/`avc2`/`avc3`/`avc4`) and returns a `Vp8Info`, `Vp9Info`, `Av1Info`, or `H264Info`. Throws
+  `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
+- `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/h264/avc-info.spec.ts
+++ b/src/codec/h264/avc-info.spec.ts
@@ -1,0 +1,122 @@
+import {H264Info} from "./avc-info";
+import {AvcProfileIdc} from "./enums";
+
+describe('H264Info', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      // string,            profileIdc,                    constraintFlags, levelIdc
+      ['avc1.640028', AvcProfileIdc.HIGH, 0x00, 0x28],
+      ['avc1.4D401E', AvcProfileIdc.MAIN, 0x40, 0x1E],
+      ['avc1.42E01E', AvcProfileIdc.BASELINE, 0xE0, 0x1E],
+      ['avc1.640033', AvcProfileIdc.HIGH, 0x00, 0x33],
+      ['avc3.42C01F', AvcProfileIdc.BASELINE, 0xC0, 0x1F],
+    ])('parses %s and round-trips', (str, profileIdc, constraintFlags, levelIdc) => {
+      const info = H264Info.fromString(str as string);
+      expect(info.profileIdc).toBe(profileIdc);
+      expect(info.constraintFlags).toBe(constraintFlags);
+      expect(info.levelIdc).toBe(levelIdc);
+      expect(info.toString()).toBe(str);
+    });
+
+    it('preserves the sample-entry 4CC', () => {
+      expect(H264Info.fromString('avc3.640028').fourCC).toBe('avc3');
+      expect(H264Info.fromString('avc3.640028').toString()).toBe('avc3.640028');
+    });
+
+    it('normalizes lowercase hex to uppercase', () => {
+      expect(H264Info.fromString('avc1.64001f').toString()).toBe('avc1.64001F');
+    });
+  });
+
+  describe('profile decoding', () => {
+    it.each([
+      ['avc1.42E01E', 'Constrained Baseline'], // profile 66 + constraint_set1
+      ['avc1.42001E', 'Baseline'],
+      ['avc1.4D401E', 'Main'],
+      ['avc1.640028', 'High'],
+      ['avc1.640828', 'Progressive High'], // profile 100 + constraint_set4
+      ['avc1.640C28', 'Constrained High'], // profile 100 + constraint_set4 + constraint_set5
+      ['avc1.6E0028', 'High 10'],
+      ['avc1.6E1028', 'High 10 Intra'], // + constraint_set3
+      ['avc1.7A0028', 'High 4:2:2'],
+      ['avc1.F40028', 'High 4:4:4 Predictive'],
+      ['avc1.2C1028', 'CAVLC 4:4:4 Intra'],
+    ])('%s -> %s', (str, profile) => {
+      expect(H264Info.fromString(str as string).toHumanReadable().profile).toBe(profile);
+    });
+  });
+
+  describe('level decoding', () => {
+    it.each([
+      ['avc1.42001E', '3.0'],
+      ['avc1.640029', '4.1'],
+      ['avc1.640033', '5.1'],
+      ['avc1.64003E', '6.2'],
+      ['avc1.42100B', '1b'], // Baseline, level_idc 11 + constraint_set3 -> 1b
+      ['avc1.42000B', '1.1'], // same level_idc without constraint_set3 -> 1.1
+      ['avc1.640009', '1b'], // High profile, level_idc 9 -> 1b
+    ])('%s -> level %s', (str, level) => {
+      expect(H264Info.fromString(str as string).toHumanReadable().level).toBe(level);
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string from parts', () => {
+      const info = new H264Info();
+      info.profileIdc = AvcProfileIdc.BASELINE;
+      info.levelIdc = 0x1E;
+      info.constraintSet1 = true;
+      expect(info.toString()).toBe('avc1.42401E');
+      expect(info.toHumanReadable().profile).toBe('Constrained Baseline');
+    });
+
+    it('toggles constraint-set flags', () => {
+      const info = new H264Info();
+      info.constraintSet0 = true;
+      info.constraintSet3 = true;
+      expect(info.constraintFlags).toBe(0x90); // bit7 | bit4
+      info.constraintSet0 = false;
+      expect(info.constraintFlags).toBe(0x10);
+    });
+
+    it('serializes empty defaults', () => {
+      expect(new H264Info().toString()).toBe('avc1.000000');
+    });
+
+    it('rejects out-of-range bytes', () => {
+      expect(() => { new H264Info().profileIdc = 256; }).toThrow('profile_idc must be a byte');
+      expect(() => { new H264Info().levelIdc = -1; }).toThrow('level_idc must be a byte');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['avc1', 'avc1.6400', 'avc1.64002G', 'avc1.6400280'])(
+      'rejects malformed string %s',
+      (str) => {
+        expect(() => H264Info.fromString(str)).toThrow('Invalid AVC codec string');
+      },
+    );
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => H264Info.fromString('avc9.640028')).toThrow('Unknown codec');
+    });
+  });
+
+  describe('toHumanReadable', () => {
+    it('reports every field', () => {
+      expect(H264Info.fromString('avc1.640028').toHumanReadable()).toEqual({
+        fourCC: 'avc1',
+        profile: 'High',
+        profileIdc: 100,
+        level: '4.0',
+        levelIdc: 40,
+        constraintSet0: false,
+        constraintSet1: false,
+        constraintSet2: false,
+        constraintSet3: false,
+        constraintSet4: false,
+        constraintSet5: false,
+      });
+    });
+  });
+});

--- a/src/codec/h264/avc-info.ts
+++ b/src/codec/h264/avc-info.ts
@@ -1,0 +1,119 @@
+import {CodecInfo} from "../codec-info";
+import {padStart} from "../pad-start";
+import {
+  AVC_FOUR_CCS,
+  AvcFourCC,
+  constraintSetFlag,
+  hLevel,
+  hProfile,
+} from "./enums";
+
+function assertByte(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0 || value > 255) {
+    throw new Error(`${name} must be a byte in the range 0-255`);
+  }
+  return value;
+}
+
+// H.264 / AVC codec information.
+// Codec string (RFC 6381): <fourCC>.<profile_idc><constraint_flags><level_idc>, three bytes hex-encoded.
+export class H264Info extends CodecInfo {
+  codecName = 'h264';
+
+  private _fourCC: AvcFourCC = 'avc1';
+  private _profileIdc = 0;
+  private _constraintFlags = 0;
+  private _levelIdc = 0;
+
+  get fourCC(): AvcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: AvcFourCC) {
+    if (!AVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid AVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertByte(profileIdc, 'profile_idc');
+  }
+
+  get constraintFlags(): number {
+    return this._constraintFlags;
+  }
+
+  set constraintFlags(constraintFlags: number) {
+    this._constraintFlags = assertByte(constraintFlags, 'constraint_flags');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertByte(levelIdc, 'level_idc');
+  }
+
+  get constraintSet0(): boolean { return constraintSetFlag(this._constraintFlags, 0); }
+  set constraintSet0(on: boolean) { this.setConstraintSet(0, on); }
+  get constraintSet1(): boolean { return constraintSetFlag(this._constraintFlags, 1); }
+  set constraintSet1(on: boolean) { this.setConstraintSet(1, on); }
+  get constraintSet2(): boolean { return constraintSetFlag(this._constraintFlags, 2); }
+  set constraintSet2(on: boolean) { this.setConstraintSet(2, on); }
+  get constraintSet3(): boolean { return constraintSetFlag(this._constraintFlags, 3); }
+  set constraintSet3(on: boolean) { this.setConstraintSet(3, on); }
+  get constraintSet4(): boolean { return constraintSetFlag(this._constraintFlags, 4); }
+  set constraintSet4(on: boolean) { this.setConstraintSet(4, on); }
+  get constraintSet5(): boolean { return constraintSetFlag(this._constraintFlags, 5); }
+  set constraintSet5(on: boolean) { this.setConstraintSet(5, on); }
+
+  private setConstraintSet(n: number, on: boolean) {
+    const mask = 1 << (7 - n);
+    this._constraintFlags = on ? this._constraintFlags | mask : this._constraintFlags & ~mask;
+  }
+
+  static fromString(codecString: string): H264Info {
+    const dot = codecString.indexOf('.');
+    const fourCC = (dot === -1 ? codecString : codecString.slice(0, dot)) as AvcFourCC;
+    if (!AVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    const params = dot === -1 ? '' : codecString.slice(dot + 1);
+    if (!/^[0-9a-fA-F]{6}$/.test(params)) {
+      throw new Error('Invalid AVC codec string, expected <fourCC>.PPCCLL');
+    }
+    const info = new H264Info();
+    info.fourCC = fourCC;
+    info.profileIdc = parseInt(params.slice(0, 2), 16);
+    info.constraintFlags = parseInt(params.slice(2, 4), 16);
+    info.levelIdc = parseInt(params.slice(4, 6), 16);
+    return info;
+  }
+
+  toString(): string {
+    const hex = (value: number) => padStart(value.toString(16).toUpperCase(), 2, '0');
+    return `${this._fourCC}.${hex(this._profileIdc)}${hex(this._constraintFlags)}${hex(this._levelIdc)}`;
+  }
+
+  toHumanReadable() {
+    return {
+      fourCC: this._fourCC,
+      profile: hProfile(this._profileIdc, this._constraintFlags),
+      profileIdc: this._profileIdc,
+      level: hLevel(this._levelIdc, this._profileIdc, this._constraintFlags),
+      levelIdc: this._levelIdc,
+      constraintSet0: this.constraintSet0,
+      constraintSet1: this.constraintSet1,
+      constraintSet2: this.constraintSet2,
+      constraintSet3: this.constraintSet3,
+      constraintSet4: this.constraintSet4,
+      constraintSet5: this.constraintSet5,
+    } as const;
+  }
+}

--- a/src/codec/h264/enums.ts
+++ b/src/codec/h264/enums.ts
@@ -1,0 +1,81 @@
+// H.264 / AVC (ISO/IEC 14496-10). Codec string per RFC 6381:
+//   <fourCC>.<profile_idc><constraint_flags><level_idc>  (three bytes, hex-encoded)
+// e.g. avc1.640028 = High profile, level 4.0.
+
+// Sample-entry 4CCs that carry an AVCDecoderConfigurationRecord.
+export type AvcFourCC = 'avc1' | 'avc2' | 'avc3' | 'avc4';
+export const AVC_FOUR_CCS: readonly AvcFourCC[] = ['avc1', 'avc2', 'avc3', 'avc4'];
+
+// Common profile_idc values (ISO/IEC 14496-10 Annex A and amendments).
+export enum AvcProfileIdc {
+  CAVLC_4_4_4_INTRA = 44,
+  BASELINE = 66,
+  MAIN = 77,
+  SCALABLE_BASELINE = 83,
+  SCALABLE_HIGH = 86,
+  EXTENDED = 88,
+  HIGH = 100,
+  HIGH_10 = 110,
+  MULTIVIEW_HIGH = 118,
+  HIGH_4_2_2 = 122,
+  STEREO_HIGH = 128,
+  MULTIVIEW_DEPTH_HIGH = 138,
+  HIGH_4_4_4_PREDICTIVE = 244,
+}
+
+// constraint_set flags byte: bit 7 = constraint_set0_flag ... bit 2 = constraint_set5_flag,
+// bits 1..0 reserved. constraint_setN_flag lives at bit (7 - N).
+export function constraintSetFlag(constraintFlags: number, n: number): boolean {
+  return Boolean((constraintFlags >> (7 - n)) & 1);
+}
+
+export function hProfile(profileIdc: number, constraintFlags: number): string {
+  const cs = (n: number) => constraintSetFlag(constraintFlags, n);
+  switch (profileIdc) {
+    case AvcProfileIdc.CAVLC_4_4_4_INTRA:
+      return 'CAVLC 4:4:4 Intra';
+    case AvcProfileIdc.BASELINE:
+      return cs(1) ? 'Constrained Baseline' : 'Baseline';
+    case AvcProfileIdc.MAIN:
+      return 'Main';
+    case AvcProfileIdc.SCALABLE_BASELINE:
+      return 'Scalable Baseline';
+    case AvcProfileIdc.SCALABLE_HIGH:
+      return 'Scalable High';
+    case AvcProfileIdc.EXTENDED:
+      return 'Extended';
+    case AvcProfileIdc.HIGH:
+      if (cs(4) && cs(5)) return 'Constrained High';
+      if (cs(4)) return 'Progressive High';
+      return 'High';
+    case AvcProfileIdc.HIGH_10:
+      return cs(3) ? 'High 10 Intra' : 'High 10';
+    case AvcProfileIdc.MULTIVIEW_HIGH:
+      return 'Multiview High';
+    case AvcProfileIdc.HIGH_4_2_2:
+      return cs(3) ? 'High 4:2:2 Intra' : 'High 4:2:2';
+    case AvcProfileIdc.STEREO_HIGH:
+      return 'Stereo High';
+    case AvcProfileIdc.MULTIVIEW_DEPTH_HIGH:
+      return 'Multiview Depth High';
+    case AvcProfileIdc.HIGH_4_4_4_PREDICTIVE:
+      return cs(3) ? 'High 4:4:4 Intra' : 'High 4:4:4 Predictive';
+    default:
+      return 'unknown';
+  }
+}
+
+export function hLevel(levelIdc: number, profileIdc: number, constraintFlags: number): string {
+  // Level 1b is signalled either by level_idc 11 + constraint_set3_flag (Baseline/Main/Extended)
+  // or by level_idc 9 for the High profiles.
+  if (levelIdc === 11 && constraintSetFlag(constraintFlags, 3) &&
+      [AvcProfileIdc.BASELINE, AvcProfileIdc.MAIN, AvcProfileIdc.EXTENDED].includes(profileIdc)) {
+    return '1b';
+  }
+  if (levelIdc === 9 &&
+      [AvcProfileIdc.HIGH, AvcProfileIdc.HIGH_10, AvcProfileIdc.HIGH_4_2_2, AvcProfileIdc.HIGH_4_4_4_PREDICTIVE].includes(profileIdc)) {
+    return '1b';
+  }
+  if (levelIdc <= 0) return 'unknown';
+  return `${Math.floor(levelIdc / 10)}.${levelIdc % 10}`;
+}

--- a/src/codec/h264/index.ts
+++ b/src/codec/h264/index.ts
@@ -1,0 +1,3 @@
+export {AvcProfileIdc, AVC_FOUR_CCS, hProfile, hLevel, constraintSetFlag} from './enums';
+export type {AvcFourCC} from './enums';
+export * from './avc-info';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1} from './index';
+import {codecInfoFactory, version, vpx, av1, h264} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -19,9 +19,16 @@ describe('codecInfoFactory', () => {
     expect((info as av1.Av1Info).profile).toBe(av1.Av1Profile.MAIN);
   });
 
+  it('dispatches avc strings to H264Info', () => {
+    const info = codecInfoFactory('avc1.640028');
+    expect(info).toBeInstanceOf(h264.H264Info);
+    expect(info.codecName).toBe('h264');
+    expect((info as h264.H264Info).profileIdc).toBe(h264.AvcProfileIdc.HIGH);
+  });
+
   it('throws on an unknown codec', () => {
-    expect(() => codecInfoFactory('avc1.640028')).toThrow('Unknown codec');
-    expect(() => codecInfoFactory('hev1.1.6.L93.B0')).toThrow('Unknown codec');
+    expect(() => codecInfoFactory('mp4a.40.2')).toThrow('Unknown codec');
+    expect(() => codecInfoFactory('theora')).toThrow('Unknown codec');
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import {vpxInfoFactory} from "./codec/vpx";
 import {Av1Info} from "./codec/av1";
+import {H264Info} from "./codec/h264";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
+export * as h264 from "./codec/h264";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -13,6 +15,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('av01')) {
     return Av1Info.fromString(codecString);
+  }
+  if (codecString.startsWith('avc')) {
+    return H264Info.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
## Summary

Adds H.264 / AVC codec-string support — the first of the h264 → h265 → h266 series (each a separate PR).

## Format (RFC 6381)

`<fourCC>.<profile_idc><constraint_flags><level_idc>` — three bytes, hex-encoded, e.g. `avc1.640028`
(High profile, level 4.0). Supported sample entries: `avc1`, `avc2`, `avc3`, `avc4`.

## What's included

- **`h264.H264Info`** with `fromString()` / `toString()` / `toHumanReadable()`.
- Raw-byte fields (`profileIdc`, `constraintFlags`, `levelIdc`) plus `constraintSet0..5` boolean
  accessors and the sample-entry `fourCC`.
- Profile decoding including the constraint-flag refinements: Constrained Baseline, Progressive /
  Constrained High, and the `*Intra` variants.
- Level decoding including both **level 1b** special cases (level_idc 11 + constraint_set3 for
  Baseline/Main/Extended, and level_idc 9 for the High profiles).
- Output normalized to uppercase hex; wired into `codecInfoFactory` via the `avc` prefix.

## Tests

36 new tests: round-trips of canonical RFC strings, profile/level decoding matrices, builder and
constraint-flag toggling, `toHumanReadable`, and malformed-input rejection. Full suite: 88 passing.

## Release

`feat:` → semantic-release will cut a **minor** bump on the next release from `main`.

> Depends on nothing else, but note PR #3 (the release-pipeline fix) should land first so this feature
> actually publishes.
