### PR TITLE
feat: add H.265 (HEVC) codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | VP9   | ✅    | ✅       |
 | AV1   | ✅    | ✅       |
 | H.264 (AVC) | ✅ | ✅   |
-| H.265 (HEVC) | ⬜ | ⬜  |
+| H.265 (HEVC) | ✅ | ✅  |
 | H.266 (VVC) | ⬜ | ⬜   |
 
 ## Install
@@ -91,11 +91,12 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`) and returns a `Vp8Info`, `Vp9Info`, `Av1Info`, or `H264Info`. Throws
-  `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`) and returns a `Vp8Info`, `Vp9Info`, `Av1Info`,
+  `H264Info`, or `H265Info`. Throws `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
+- `h265` — namespace exporting `H265Info`, `HevcProfileIdc`, and the `hProfile`/`hLevel`/`hTier` helpers.
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/h265/enums.ts
+++ b/src/codec/h265/enums.ts
@@ -1,0 +1,48 @@
+// H.265 / HEVC (ISO/IEC 23008-2, carried per ISO/IEC 14496-15). Codec string per RFC 6381 / MDN:
+//   <fourCC>.<space?profile_idc>.<compat_flags_hex>.<L|H level_idc>[.<constraint bytes...>]
+// e.g. hvc1.2.4.L153.B0 = Main 10 profile, level 5.1, Main tier.
+
+export type HevcFourCC = 'hev1' | 'hvc1';
+export const HEVC_FOUR_CCS: readonly HevcFourCC[] = ['hev1', 'hvc1'];
+
+// general_profile_idc values (ISO/IEC 23008-2 Annex A and extensions).
+export enum HevcProfileIdc {
+  MAIN = 1,
+  MAIN_10 = 2,
+  MAIN_STILL_PICTURE = 3,
+  RANGE_EXTENSIONS = 4,
+  HIGH_THROUGHPUT = 5,
+  MULTIVIEW_MAIN = 6,
+  SCALABLE_MAIN = 7,
+  THREE_D_MAIN = 8,
+  SCREEN_CONTENT_CODING = 9,
+  SCALABLE_RANGE_EXTENSIONS = 10,
+  HIGH_THROUGHPUT_SCREEN_CONTENT = 11,
+}
+
+export function hProfile(profileIdc: number): string {
+  switch (profileIdc) {
+    case HevcProfileIdc.MAIN: return 'Main';
+    case HevcProfileIdc.MAIN_10: return 'Main 10';
+    case HevcProfileIdc.MAIN_STILL_PICTURE: return 'Main Still Picture';
+    case HevcProfileIdc.RANGE_EXTENSIONS: return 'Range Extensions';
+    case HevcProfileIdc.HIGH_THROUGHPUT: return 'High Throughput';
+    case HevcProfileIdc.MULTIVIEW_MAIN: return 'Multiview Main';
+    case HevcProfileIdc.SCALABLE_MAIN: return 'Scalable Main';
+    case HevcProfileIdc.THREE_D_MAIN: return '3D Main';
+    case HevcProfileIdc.SCREEN_CONTENT_CODING: return 'Screen-Extended';
+    case HevcProfileIdc.SCALABLE_RANGE_EXTENSIONS: return 'Scalable Range Extensions';
+    case HevcProfileIdc.HIGH_THROUGHPUT_SCREEN_CONTENT: return 'High Throughput Screen-Extended';
+    default: return 'unknown';
+  }
+}
+
+// HEVC levels are general_level_idc / 30 (e.g. 93 -> 3.1, 153 -> 5.1, 186 -> 6.2).
+export function hLevel(levelIdc: number): string {
+  if (levelIdc <= 0) return 'unknown';
+  return `${Math.floor(levelIdc / 30)}.${(levelIdc % 30) / 3}`;
+}
+
+export function hTier(tierFlag: number): string {
+  return tierFlag ? 'high' : 'main';
+}

--- a/src/codec/h265/hevc-info.spec.ts
+++ b/src/codec/h265/hevc-info.spec.ts
@@ -1,0 +1,134 @@
+import {H265Info} from "./hevc-info";
+import {HevcProfileIdc} from "./enums";
+
+describe('H265Info', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'hvc1.1.6.L93.B0',
+      'hev1.1.6.L150.90',
+      'hvc1.2.4.L153.B0',
+      'hvc1.A4.4.H120',
+      'hev1.1.6.L150.90.90',
+      'hvc1.3.E.L120.90',
+    ])('parses and round-trips %s', (str) => {
+      expect(H265Info.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes every field of hvc1.2.4.L153.B0', () => {
+      const info = H265Info.fromString('hvc1.2.4.L153.B0');
+      expect(info.fourCC).toBe('hvc1');
+      expect(info.profileSpace).toBe(0);
+      expect(info.profileIdc).toBe(HevcProfileIdc.MAIN_10);
+      expect(info.compatibilityFlags).toBe(0x4);
+      expect(info.tierFlag).toBe(0);
+      expect(info.levelIdc).toBe(153);
+      expect(info.constraintFlags).toEqual([0xB0]);
+    });
+
+    it('parses the profile-space letter prefix', () => {
+      expect(H265Info.fromString('hvc1.A1.6.L93').profileSpace).toBe(1);
+      expect(H265Info.fromString('hvc1.B1.6.L93').profileSpace).toBe(2);
+      expect(H265Info.fromString('hvc1.C1.6.L93').profileSpace).toBe(3);
+    });
+
+    it('trims trailing zero constraint bytes', () => {
+      expect(H265Info.fromString('hvc1.1.6.L93.B0.00.00').toString()).toBe('hvc1.1.6.L93.B0');
+    });
+
+    it('parses the high tier', () => {
+      const info = H265Info.fromString('hvc1.1.6.H120');
+      expect(info.tierFlag).toBe(1);
+      expect(info.toString()).toBe('hvc1.1.6.H120');
+    });
+  });
+
+  describe('profile decoding', () => {
+    it.each([
+      ['hvc1.1.6.L93', 'Main'],
+      ['hvc1.2.4.L93', 'Main 10'],
+      ['hvc1.3.0.L93', 'Main Still Picture'],
+      ['hvc1.4.0.L93', 'Range Extensions'],
+    ])('%s -> %s', (str, profile) => {
+      expect(H265Info.fromString(str).toHumanReadable().profile).toBe(profile);
+    });
+  });
+
+  describe('level decoding', () => {
+    it.each([
+      ['hvc1.1.6.L30', '1.0'],
+      ['hvc1.1.6.L63', '2.1'],
+      ['hvc1.1.6.L93', '3.1'],
+      ['hvc1.1.6.L120', '4.0'],
+      ['hvc1.1.6.L153', '5.1'],
+      ['hvc1.1.6.L156', '5.2'],
+      ['hvc1.1.6.L186', '6.2'],
+    ])('%s -> level %s', (str, level) => {
+      expect(H265Info.fromString(str).toHumanReadable().level).toBe(level);
+    });
+
+    it('reports the tier name', () => {
+      expect(H265Info.fromString('hvc1.1.6.L93').toHumanReadable().tier).toBe('main');
+      expect(H265Info.fromString('hvc1.1.6.H93').toHumanReadable().tier).toBe('high');
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string from parts', () => {
+      const info = new H265Info();
+      info.fourCC = 'hvc1';
+      info.profileIdc = HevcProfileIdc.MAIN;
+      info.compatibilityFlags = 0x6;
+      info.levelIdc = 93;
+      info.constraintFlags = [0xB0];
+      expect(info.toString()).toBe('hvc1.1.6.L93.B0');
+    });
+
+    it('emits the profile-space letter and high tier', () => {
+      const info = new H265Info();
+      info.profileSpace = 1;
+      info.profileIdc = 4;
+      info.compatibilityFlags = 0x4;
+      info.tierFlag = 1;
+      info.levelIdc = 120;
+      expect(info.toString()).toBe('hvc1.A4.4.H120');
+    });
+
+    it('rejects out-of-range fields', () => {
+      expect(() => { new H265Info().profileSpace = 4; }).toThrow('general_profile_space');
+      expect(() => { new H265Info().profileIdc = 32; }).toThrow('general_profile_idc');
+      expect(() => { new H265Info().levelIdc = 256; }).toThrow('general_level_idc');
+      expect(() => { new H265Info().tierFlag = 2; }).toThrow('general_tier_flag');
+      expect(() => { new H265Info().constraintFlags = [1, 2, 3, 4, 5, 6, 7]; })
+        .toThrow('at most 6 bytes');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['hvc1', 'hvc1.1.6', 'hvc1.1.GG.L93', 'hvc1.1.6.X93', 'hvc1.1.6.L93.01.02.03.04.05.06.07'])(
+      'rejects malformed string %s',
+      (str) => {
+        expect(() => H265Info.fromString(str)).toThrow(/Invalid HEVC|Unknown codec/);
+      },
+    );
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => H265Info.fromString('hvc9.1.6.L93')).toThrow('Unknown codec');
+    });
+  });
+
+  describe('toHumanReadable', () => {
+    it('reports every field', () => {
+      expect(H265Info.fromString('hvc1.2.4.L153.B0').toHumanReadable()).toEqual({
+        fourCC: 'hvc1',
+        profileSpace: 0,
+        profile: 'Main 10',
+        profileIdc: 2,
+        compatibilityFlags: '4',
+        tier: 'main',
+        level: '5.1',
+        levelIdc: 153,
+        constraintFlags: 'B0',
+      });
+    });
+  });
+});

--- a/src/codec/h265/hevc-info.ts
+++ b/src/codec/h265/hevc-info.ts
@@ -1,0 +1,165 @@
+import {CodecInfo} from "../codec-info";
+import {padStart} from "../pad-start";
+import {HEVC_FOUR_CCS, HevcFourCC, hLevel, hProfile, hTier} from "./enums";
+
+function assertRange(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in the range ${min}-${max}`);
+  }
+  return value;
+}
+
+function trimTrailingZeros(bytes: number[]): number[] {
+  const out = [...bytes];
+  while (out.length > 0 && out[out.length - 1] === 0) {
+    out.pop();
+  }
+  return out;
+}
+
+// H.265 / HEVC codec information.
+// Codec string (RFC 6381): <fourCC>.<space?profile_idc>.<compat_hex>.<L|H level_idc>[.<constraint bytes>].
+export class H265Info extends CodecInfo {
+  codecName = 'h265';
+
+  private _fourCC: HevcFourCC = 'hvc1';
+  private _profileSpace = 0;
+  private _profileIdc = 0;
+  private _compatibilityFlags = 0;
+  private _tierFlag = 0;
+  private _levelIdc = 0;
+  private _constraintFlags: number[] = [];
+
+  get fourCC(): HevcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: HevcFourCC) {
+    if (!HEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid HEVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileSpace(): number {
+    return this._profileSpace;
+  }
+
+  set profileSpace(profileSpace: number) {
+    this._profileSpace = assertRange(profileSpace, 0, 3, 'general_profile_space');
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertRange(profileIdc, 0, 31, 'general_profile_idc');
+  }
+
+  get compatibilityFlags(): number {
+    return this._compatibilityFlags;
+  }
+
+  set compatibilityFlags(compatibilityFlags: number) {
+    this._compatibilityFlags = assertRange(compatibilityFlags, 0, 0xffffffff, 'general_profile_compatibility_flags');
+  }
+
+  get tierFlag(): number {
+    return this._tierFlag;
+  }
+
+  set tierFlag(tierFlag: number) {
+    this._tierFlag = assertRange(tierFlag, 0, 1, 'general_tier_flag');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertRange(levelIdc, 0, 255, 'general_level_idc');
+  }
+
+  get constraintFlags(): number[] {
+    return [...this._constraintFlags];
+  }
+
+  set constraintFlags(constraintFlags: number[]) {
+    if (constraintFlags.length > 6) {
+      throw new Error('general_constraint_indicator_flags is at most 6 bytes');
+    }
+    constraintFlags.forEach((b, i) => assertRange(b, 0, 255, `constraint byte ${i}`));
+    this._constraintFlags = [...constraintFlags];
+  }
+
+  static fromString(codecString: string): H265Info {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as HevcFourCC;
+    if (!HEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    if (parts.length < 4 || parts.length > 10) {
+      throw new Error('Invalid HEVC codec string, expected <fourCC>.<profile>.<compat>.<tier+level>[.constraints]');
+    }
+    const info = new H265Info();
+    info.fourCC = fourCC;
+
+    // A: optional profile-space letter (A/B/C = 1/2/3) followed by general_profile_idc.
+    const profileMatch = parts[1].match(/^([ABC]?)(\d+)$/);
+    if (!profileMatch) {
+      throw new Error('Invalid HEVC profile component');
+    }
+    info.profileSpace = profileMatch[1] ? profileMatch[1].charCodeAt(0) - 64 : 0;
+    info.profileIdc = parseInt(profileMatch[2], 10);
+
+    // B: general_profile_compatibility_flags as a 32-bit hex value.
+    if (!/^[0-9a-fA-F]{1,8}$/.test(parts[2])) {
+      throw new Error('Invalid HEVC compatibility flags');
+    }
+    info.compatibilityFlags = parseInt(parts[2], 16);
+
+    // C: tier flag (L/H) followed by general_level_idc.
+    const tierMatch = parts[3].match(/^([LH])(\d+)$/);
+    if (!tierMatch) {
+      throw new Error('Invalid HEVC tier/level component');
+    }
+    info.tierFlag = tierMatch[1] === 'H' ? 1 : 0;
+    info.levelIdc = parseInt(tierMatch[2], 10);
+
+    // D: up to six constraint bytes, hex-encoded.
+    info.constraintFlags = parts.slice(4).map((byte, i) => {
+      if (!/^[0-9a-fA-F]{1,2}$/.test(byte)) {
+        throw new Error(`Invalid HEVC constraint byte ${i}`);
+      }
+      return parseInt(byte, 16);
+    });
+
+    return info;
+  }
+
+  toString(): string {
+    const partA = `${this._profileSpace ? String.fromCharCode(64 + this._profileSpace) : ''}${this._profileIdc}`;
+    const partB = this._compatibilityFlags.toString(16).toUpperCase();
+    const partC = `${this._tierFlag ? 'H' : 'L'}${this._levelIdc}`;
+    const constraints = trimTrailingZeros(this._constraintFlags)
+      .map((byte) => padStart(byte.toString(16).toUpperCase(), 2, '0'));
+    return [this._fourCC, partA, partB, partC, ...constraints].join('.');
+  }
+
+  toHumanReadable() {
+    const constraints = trimTrailingZeros(this._constraintFlags)
+      .map((byte) => padStart(byte.toString(16).toUpperCase(), 2, '0'));
+    return {
+      fourCC: this._fourCC,
+      profileSpace: this._profileSpace,
+      profile: hProfile(this._profileIdc),
+      profileIdc: this._profileIdc,
+      compatibilityFlags: this._compatibilityFlags.toString(16).toUpperCase(),
+      tier: hTier(this._tierFlag),
+      level: hLevel(this._levelIdc),
+      levelIdc: this._levelIdc,
+      constraintFlags: constraints.length ? constraints.join('.') : 'none',
+    } as const;
+  }
+}

--- a/src/codec/h265/index.ts
+++ b/src/codec/h265/index.ts
@@ -1,0 +1,3 @@
+export {HevcProfileIdc, HEVC_FOUR_CCS, hProfile, hLevel, hTier} from './enums';
+export type {HevcFourCC} from './enums';
+export * from './hevc-info';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -24,6 +24,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(h264.H264Info);
     expect(info.codecName).toBe('h264');
     expect((info as h264.H264Info).profileIdc).toBe(h264.AvcProfileIdc.HIGH);
+  });
+
+  it('dispatches hev/hvc strings to H265Info', () => {
+    const info = codecInfoFactory('hvc1.1.6.L93.B0');
+    expect(info).toBeInstanceOf(h265.H265Info);
+    expect(info.codecName).toBe('h265');
+    expect((info as h265.H265Info).levelIdc).toBe(93);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import {vpxInfoFactory} from "./codec/vpx";
 import {Av1Info} from "./codec/av1";
 import {H264Info} from "./codec/h264";
+import {H265Info} from "./codec/h265";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
 export * as h264 from "./codec/h264";
+export * as h265 from "./codec/h265";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -18,6 +20,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('avc')) {
     return H264Info.fromString(codecString);
+  }
+  if (codecString.startsWith('hev') || codecString.startsWith('hvc')) {
+    return H265Info.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Rebased onto `main` after H.264 landed (supersedes the auto-closed #5). Adds hev1/hvc1 parsing and generation: general_profile_space + profile_idc, 32-bit compatibility flags, tier (L/H) + level_idc (level = idc/30), and up to six constraint bytes (trailing zeros trimmed). 33 tests; full suite 121 passing.

`feat:` → minor bump (0.2.0).