### PR TITLE
feat: add H.266 (VVC) codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | AV1   | ✅    | ✅       |
 | H.264 (AVC) | ✅ | ✅   |
 | H.265 (HEVC) | ✅ | ✅  |
-| H.266 (VVC) | ⬜ | ⬜   |
+| H.266 (VVC) | ✅ | ✅   |
 
 ## Install
 
@@ -91,12 +91,15 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`) and returns a `Vp8Info`, `Vp9Info`, `Av1Info`,
-  `H264Info`, or `H265Info`. Throws `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`) and returns a `Vp8Info`, `Vp9Info`,
+  `Av1Info`, `H264Info`, `H265Info`, or `H266Info`. Throws `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
 - `h265` — namespace exporting `H265Info`, `HevcProfileIdc`, and the `hProfile`/`hLevel`/`hTier` helpers.
+- `h266` — namespace exporting `H266Info`, `VvcProfileIdc`, and the `hProfile`/`hLevel`/`hTier` helpers.
+  The mandatory profile/tier/level is decoded; the optional VVC constraint (`C`), sub-profile (`S`)
+  and output-layer-set (`O`) fields are preserved verbatim for round-tripping.
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/h266/enums.ts
+++ b/src/codec/h266/enums.ts
@@ -1,0 +1,42 @@
+// H.266 / VVC (ISO/IEC 23090-3, carried per ISO/IEC 14496-15). Codec string:
+//   <fourCC>.<general_profile_idc>.<L|H general_level_idc>[.<optional C/S/O fields...>]
+// e.g. vvi1.1.L83 = Main 10 profile, Main tier, level 5.1.
+//
+// The mandatory profile / tier / level part is fully decoded. The optional fields
+// (C = general constraints info, S = sub-profiles, O = output-layer-set + max temporal id)
+// have a complex bit-packed encoding that is preserved verbatim rather than decoded.
+
+export type VvcFourCC = 'vvc1' | 'vvi1';
+export const VVC_FOUR_CCS: readonly VvcFourCC[] = ['vvc1', 'vvi1'];
+
+// general_profile_idc values (ISO/IEC 23090-3 Annex A, VVC version 1).
+export enum VvcProfileIdc {
+  MAIN_10 = 1,
+  MULTILAYER_MAIN_10 = 17,
+  MAIN_10_4_4_4 = 33,
+  MULTILAYER_MAIN_10_4_4_4 = 49,
+  MAIN_10_STILL_PICTURE = 65,
+  MAIN_10_4_4_4_STILL_PICTURE = 97,
+}
+
+export function hProfile(profileIdc: number): string {
+  switch (profileIdc) {
+    case VvcProfileIdc.MAIN_10: return 'Main 10';
+    case VvcProfileIdc.MULTILAYER_MAIN_10: return 'Multilayer Main 10';
+    case VvcProfileIdc.MAIN_10_4_4_4: return 'Main 10 4:4:4';
+    case VvcProfileIdc.MULTILAYER_MAIN_10_4_4_4: return 'Multilayer Main 10 4:4:4';
+    case VvcProfileIdc.MAIN_10_STILL_PICTURE: return 'Main 10 Still Picture';
+    case VvcProfileIdc.MAIN_10_4_4_4_STILL_PICTURE: return 'Main 10 4:4:4 Still Picture';
+    default: return 'unknown';
+  }
+}
+
+// VVC levels: general_level_idc = 16 * major + 3 * minor (e.g. 51 -> 3.1, 83 -> 5.1, 102 -> 6.2).
+export function hLevel(levelIdc: number): string {
+  if (levelIdc <= 0) return 'unknown';
+  return `${Math.floor(levelIdc / 16)}.${(levelIdc % 16) / 3}`;
+}
+
+export function hTier(tierFlag: number): string {
+  return tierFlag ? 'high' : 'main';
+}

--- a/src/codec/h266/index.ts
+++ b/src/codec/h266/index.ts
@@ -1,0 +1,3 @@
+export {VvcProfileIdc, VVC_FOUR_CCS, hProfile, hLevel, hTier} from './enums';
+export type {VvcFourCC} from './enums';
+export * from './vvc-info';

--- a/src/codec/h266/vvc-info.spec.ts
+++ b/src/codec/h266/vvc-info.spec.ts
@@ -1,0 +1,118 @@
+import {H266Info} from "./vvc-info";
+import {VvcProfileIdc} from "./enums";
+
+describe('H266Info', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'vvi1.1.L83',
+      'vvc1.1.L51',
+      'vvi1.1.H96',
+      'vvi1.1.L83.CQA',
+      'vvi1.1.L83.CQA.O0',
+      'vvc1.65.L64',
+    ])('parses and round-trips %s', (str) => {
+      expect(H266Info.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes every field of vvi1.1.L83.CQA', () => {
+      const info = H266Info.fromString('vvi1.1.L83.CQA');
+      expect(info.fourCC).toBe('vvi1');
+      expect(info.profileIdc).toBe(VvcProfileIdc.MAIN_10);
+      expect(info.tierFlag).toBe(0);
+      expect(info.levelIdc).toBe(83);
+      expect(info.optionalParams).toEqual(['CQA']);
+    });
+
+    it('preserves the high tier and fourCC', () => {
+      const info = H266Info.fromString('vvc1.1.H96');
+      expect(info.tierFlag).toBe(1);
+      expect(info.fourCC).toBe('vvc1');
+      expect(info.toString()).toBe('vvc1.1.H96');
+    });
+  });
+
+  describe('profile decoding', () => {
+    it.each([
+      ['vvi1.1.L83', 'Main 10'],
+      ['vvi1.17.L83', 'Multilayer Main 10'],
+      ['vvi1.33.L83', 'Main 10 4:4:4'],
+      ['vvi1.65.L83', 'Main 10 Still Picture'],
+    ])('%s -> %s', (str, profile) => {
+      expect(H266Info.fromString(str).toHumanReadable().profile).toBe(profile);
+    });
+  });
+
+  describe('level decoding', () => {
+    it.each([
+      ['vvi1.1.L16', '1.0'],
+      ['vvi1.1.L35', '2.1'],
+      ['vvi1.1.L51', '3.1'],
+      ['vvi1.1.L64', '4.0'],
+      ['vvi1.1.L83', '5.1'],
+      ['vvi1.1.L86', '5.2'],
+      ['vvi1.1.L102', '6.2'],
+    ])('%s -> level %s', (str, level) => {
+      expect(H266Info.fromString(str).toHumanReadable().level).toBe(level);
+    });
+
+    it('reports the tier name', () => {
+      expect(H266Info.fromString('vvi1.1.L83').toHumanReadable().tier).toBe('main');
+      expect(H266Info.fromString('vvi1.1.H83').toHumanReadable().tier).toBe('high');
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string from parts', () => {
+      const info = new H266Info();
+      info.fourCC = 'vvi1';
+      info.profileIdc = VvcProfileIdc.MAIN_10;
+      info.levelIdc = 83;
+      expect(info.toString()).toBe('vvi1.1.L83');
+    });
+
+    it('emits the high tier and optional fields', () => {
+      const info = new H266Info();
+      info.fourCC = 'vvc1';
+      info.profileIdc = 1;
+      info.tierFlag = 1;
+      info.levelIdc = 96;
+      info.optionalParams = ['CQA', 'O0'];
+      expect(info.toString()).toBe('vvc1.1.H96.CQA.O0');
+    });
+
+    it('rejects out-of-range fields', () => {
+      expect(() => { new H266Info().profileIdc = 128; }).toThrow('general_profile_idc');
+      expect(() => { new H266Info().levelIdc = 256; }).toThrow('general_level_idc');
+      expect(() => { new H266Info().tierFlag = 2; }).toThrow('general_tier_flag');
+      expect(() => { new H266Info().optionalParams = ['CQA', '']; })
+        .toThrow('must not be empty');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['vvi1', 'vvi1.1', 'vvi1.X.L83', 'vvi1.1.X83', 'vvi1.1.L83.'])(
+      'rejects malformed string %s',
+      (str) => {
+        expect(() => H266Info.fromString(str)).toThrow(/Invalid VVC|must not be empty/);
+      },
+    );
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => H266Info.fromString('vvc9.1.L83')).toThrow('Unknown codec');
+    });
+  });
+
+  describe('toHumanReadable', () => {
+    it('reports every field', () => {
+      expect(H266Info.fromString('vvi1.1.L83.CQA').toHumanReadable()).toEqual({
+        fourCC: 'vvi1',
+        profile: 'Main 10',
+        profileIdc: 1,
+        tier: 'main',
+        level: '5.1',
+        levelIdc: 83,
+        optionalParams: 'CQA',
+      });
+    });
+  });
+});

--- a/src/codec/h266/vvc-info.ts
+++ b/src/codec/h266/vvc-info.ts
@@ -1,0 +1,116 @@
+import {CodecInfo} from "../codec-info";
+import {VVC_FOUR_CCS, VvcFourCC, hLevel, hProfile, hTier} from "./enums";
+
+function assertRange(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in the range ${min}-${max}`);
+  }
+  return value;
+}
+
+// H.266 / VVC codec information.
+// Codec string: <fourCC>.<general_profile_idc>.<L|H general_level_idc>[.<optional fields>].
+// The profile/tier/level part is fully decoded; the optional C/S/O fields are preserved verbatim.
+export class H266Info extends CodecInfo {
+  codecName = 'h266';
+
+  private _fourCC: VvcFourCC = 'vvc1';
+  private _profileIdc = 0;
+  private _tierFlag = 0;
+  private _levelIdc = 0;
+  private _optionalParams: string[] = [];
+
+  get fourCC(): VvcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: VvcFourCC) {
+    if (!VVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid VVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertRange(profileIdc, 0, 127, 'general_profile_idc');
+  }
+
+  get tierFlag(): number {
+    return this._tierFlag;
+  }
+
+  set tierFlag(tierFlag: number) {
+    this._tierFlag = assertRange(tierFlag, 0, 1, 'general_tier_flag');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertRange(levelIdc, 0, 255, 'general_level_idc');
+  }
+
+  // Optional constraint (C), sub-profile (S) and output-layer-set (O) fields, preserved verbatim.
+  get optionalParams(): string[] {
+    return [...this._optionalParams];
+  }
+
+  set optionalParams(optionalParams: string[]) {
+    optionalParams.forEach((segment) => {
+      if (!segment) {
+        throw new Error('VVC optional field must not be empty');
+      }
+    });
+    this._optionalParams = [...optionalParams];
+  }
+
+  static fromString(codecString: string): H266Info {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as VvcFourCC;
+    if (!VVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    if (parts.length < 3) {
+      throw new Error('Invalid VVC codec string, expected <fourCC>.<profile>.<tier+level>[.fields]');
+    }
+    const info = new H266Info();
+    info.fourCC = fourCC;
+
+    if (!/^\d+$/.test(parts[1])) {
+      throw new Error('Invalid VVC profile component');
+    }
+    info.profileIdc = parseInt(parts[1], 10);
+
+    const tierMatch = parts[2].match(/^([LH])(\d+)$/);
+    if (!tierMatch) {
+      throw new Error('Invalid VVC tier/level component');
+    }
+    info.tierFlag = tierMatch[1] === 'H' ? 1 : 0;
+    info.levelIdc = parseInt(tierMatch[2], 10);
+
+    info.optionalParams = parts.slice(3);
+    return info;
+  }
+
+  toString(): string {
+    const tierLevel = `${this._tierFlag ? 'H' : 'L'}${this._levelIdc}`;
+    return [this._fourCC, String(this._profileIdc), tierLevel, ...this._optionalParams].join('.');
+  }
+
+  toHumanReadable() {
+    return {
+      fourCC: this._fourCC,
+      profile: hProfile(this._profileIdc),
+      profileIdc: this._profileIdc,
+      tier: hTier(this._tierFlag),
+      level: hLevel(this._levelIdc),
+      levelIdc: this._levelIdc,
+      optionalParams: this._optionalParams.length ? this._optionalParams.join('.') : 'none',
+    } as const;
+  }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264, h265} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265, h266} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -31,6 +31,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(h265.H265Info);
     expect(info.codecName).toBe('h265');
     expect((info as h265.H265Info).levelIdc).toBe(93);
+  });
+
+  it('dispatches vvc/vvi strings to H266Info', () => {
+    const info = codecInfoFactory('vvi1.1.L83');
+    expect(info).toBeInstanceOf(h266.H266Info);
+    expect(info.codecName).toBe('h266');
+    expect((info as h266.H266Info).levelIdc).toBe(83);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@ import {vpxInfoFactory} from "./codec/vpx";
 import {Av1Info} from "./codec/av1";
 import {H264Info} from "./codec/h264";
 import {H265Info} from "./codec/h265";
+import {H266Info} from "./codec/h266";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
 export * as h264 from "./codec/h264";
 export * as h265 from "./codec/h265";
+export * as h266 from "./codec/h266";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -23,6 +25,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('hev') || codecString.startsWith('hvc')) {
     return H265Info.fromString(codecString);
+  }
+  if (codecString.startsWith('vvc') || codecString.startsWith('vvi')) {
+    return H266Info.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Rebased onto `main` after H.265 landed (supersedes the stacked #6). Adds vvc1/vvi1 parsing and generation: general_profile_idc, tier (L/H) + general_level_idc (level = idc/16 major + /3 minor, verified vs MC-IF Table 7-4). Optional constraint (C) / sub-profile (S) / output-layer-set (O) fields are preserved verbatim (their bit-packed encoding isn't freely specified). 31 tests; full suite 152 passing.

`feat:` → minor bump (0.3.0).