### PR TITLE
feat: add LCEVC codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | H.264 (AVC) | ✅ | ✅   |
 | H.265 (HEVC) | ✅ | ✅  |
 | H.266 (VVC) | ✅ | ✅   |
+| LCEVC | ✅ | ✅          |
 
 ## Install
 
@@ -91,8 +92,8 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`) and returns a `Vp8Info`, `Vp9Info`,
-  `Av1Info`, `H264Info`, `H265Info`, or `H266Info`. Throws `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`) and returns a `Vp8Info`, `Vp9Info`,
+  `Av1Info`, `H264Info`, `H265Info`, `H266Info`, or `LcevcInfo`. Throws `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
@@ -100,6 +101,8 @@ console.log(info.toString());                // 'avc1.640028'
 - `h266` — namespace exporting `H266Info`, `VvcProfileIdc`, and the `hProfile`/`hLevel`/`hTier` helpers.
   The mandatory profile/tier/level is decoded; the optional VVC constraint (`C`), sub-profile (`S`)
   and output-layer-set (`O`) fields are preserved verbatim for round-tripping.
+- `lcevc` — namespace exporting `LcevcInfo` and `LcevcProfile` (MPEG-5 Part 2 enhancement codec,
+  `lvc1.vprf<profile>.vlev<level>`).
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/lcevc/enums.ts
+++ b/src/codec/lcevc/enums.ts
@@ -1,0 +1,24 @@
+// LCEVC / MPEG-5 Part 2 (ISO/IEC 23094-2), carried per ISO/IEC 14496-15. Codec string:
+//   lvc1.vprf<profile_idc>.vlev<level_idc>
+// e.g. lvc1.vprf0.vlev4 = Main profile, level 4. LCEVC is an enhancement layer over a base codec.
+
+export type LcevcFourCC = 'lvc1';
+export const LCEVC_FOUR_CCS: readonly LcevcFourCC[] = ['lvc1'];
+
+export enum LcevcProfile {
+  MAIN = 0,
+  MAIN_4_4_4 = 1,
+}
+
+export function hProfile(profileIdc: number): string {
+  switch (profileIdc) {
+    case LcevcProfile.MAIN: return 'Main';
+    case LcevcProfile.MAIN_4_4_4: return 'Main 4:4:4';
+    default: return 'unknown';
+  }
+}
+
+export function hLevel(levelIdc: number): string {
+  if (levelIdc <= 0) return 'unknown';
+  return String(levelIdc);
+}

--- a/src/codec/lcevc/index.ts
+++ b/src/codec/lcevc/index.ts
@@ -1,0 +1,3 @@
+export {LcevcProfile, LCEVC_FOUR_CCS, hProfile, hLevel} from './enums';
+export type {LcevcFourCC} from './enums';
+export * from './lcevc-info';

--- a/src/codec/lcevc/lcevc-info.spec.ts
+++ b/src/codec/lcevc/lcevc-info.spec.ts
@@ -1,0 +1,83 @@
+import {LcevcInfo} from "./lcevc-info";
+import {LcevcProfile} from "./enums";
+
+describe('LcevcInfo', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'lvc1.vprf0.vlev4',
+      'lvc1.vprf1.vlev2',
+      'lvc1.vprf0.vlev1',
+    ])('parses and round-trips %s', (str) => {
+      expect(LcevcInfo.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes the fields', () => {
+      const info = LcevcInfo.fromString('lvc1.vprf1.vlev3');
+      expect(info.fourCC).toBe('lvc1');
+      expect(info.profileIdc).toBe(LcevcProfile.MAIN_4_4_4);
+      expect(info.levelIdc).toBe(3);
+    });
+
+    it('accepts case-insensitive keys and normalizes them', () => {
+      expect(LcevcInfo.fromString('lvc1.VPRF0.VLEV4').toString()).toBe('lvc1.vprf0.vlev4');
+    });
+
+    it('tolerates key order', () => {
+      expect(LcevcInfo.fromString('lvc1.vlev2.vprf1').toString()).toBe('lvc1.vprf1.vlev2');
+    });
+  });
+
+  describe('human-readable', () => {
+    it.each([
+      ['lvc1.vprf0.vlev4', 'Main'],
+      ['lvc1.vprf1.vlev4', 'Main 4:4:4'],
+    ])('%s -> %s', (str, profile) => {
+      expect(LcevcInfo.fromString(str).toHumanReadable().profile).toBe(profile);
+    });
+
+    it('reports every field', () => {
+      expect(LcevcInfo.fromString('lvc1.vprf1.vlev3').toHumanReadable()).toEqual({
+        fourCC: 'lvc1',
+        profile: 'Main 4:4:4',
+        profileIdc: 1,
+        level: '3',
+        levelIdc: 3,
+      });
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string from parts', () => {
+      const info = new LcevcInfo();
+      info.profileIdc = LcevcProfile.MAIN;
+      info.levelIdc = 4;
+      expect(info.toString()).toBe('lvc1.vprf0.vlev4');
+    });
+
+    it('rejects out-of-range fields', () => {
+      expect(() => { new LcevcInfo().profileIdc = 256; }).toThrow('vprf');
+      expect(() => { new LcevcInfo().levelIdc = -1; }).toThrow('vlev');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['lvc1', 'lvc1.vprf0', 'lvc1.vlev4'])(
+      'rejects a string missing a parameter: %s',
+      (str) => {
+        expect(() => LcevcInfo.fromString(str)).toThrow('Invalid LCEVC codec string');
+      },
+    );
+
+    it('rejects an unknown parameter key', () => {
+      expect(() => LcevcInfo.fromString('lvc1.vprf0.vlev4.vxxx1')).toThrow('Unknown LCEVC parameter');
+    });
+
+    it('rejects a non-numeric value', () => {
+      expect(() => LcevcInfo.fromString('lvc1.vprfA.vlev4')).toThrow('Invalid LCEVC parameter value');
+    });
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => LcevcInfo.fromString('lvc9.vprf0.vlev4')).toThrow('Unknown codec');
+    });
+  });
+});

--- a/src/codec/lcevc/lcevc-info.ts
+++ b/src/codec/lcevc/lcevc-info.ts
@@ -1,0 +1,92 @@
+import {CodecInfo} from "../codec-info";
+import {LCEVC_FOUR_CCS, LcevcFourCC, hLevel, hProfile} from "./enums";
+
+function assertRange(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in the range ${min}-${max}`);
+  }
+  return value;
+}
+
+// LCEVC codec information. Codec string: lvc1.vprf<profile_idc>.vlev<level_idc>.
+export class LcevcInfo extends CodecInfo {
+  codecName = 'lcevc';
+
+  private _fourCC: LcevcFourCC = 'lvc1';
+  private _profileIdc = 0;
+  private _levelIdc = 0;
+
+  get fourCC(): LcevcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: LcevcFourCC) {
+    if (!LCEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid LCEVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertRange(profileIdc, 0, 255, 'vprf (profile_idc)');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertRange(levelIdc, 0, 255, 'vlev (level_idc)');
+  }
+
+  static fromString(codecString: string): LcevcInfo {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as LcevcFourCC;
+    if (!LCEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    const info = new LcevcInfo();
+    info.fourCC = fourCC;
+
+    let hasProfile = false;
+    let hasLevel = false;
+    for (const segment of parts.slice(1)) {
+      const key = segment.slice(0, 4).toLowerCase();
+      const value = segment.slice(4);
+      if (!/^\d+$/.test(value)) {
+        throw new Error(`Invalid LCEVC parameter value: ${segment}`);
+      }
+      if (key === 'vprf') {
+        info.profileIdc = parseInt(value, 10);
+        hasProfile = true;
+      } else if (key === 'vlev') {
+        info.levelIdc = parseInt(value, 10);
+        hasLevel = true;
+      } else {
+        throw new Error(`Unknown LCEVC parameter: ${key}`);
+      }
+    }
+    if (!hasProfile || !hasLevel) {
+      throw new Error('Invalid LCEVC codec string, expected lvc1.vprf<profile>.vlev<level>');
+    }
+    return info;
+  }
+
+  toString(): string {
+    return `${this._fourCC}.vprf${this._profileIdc}.vlev${this._levelIdc}`;
+  }
+
+  toHumanReadable() {
+    return {
+      fourCC: this._fourCC,
+      profile: hProfile(this._profileIdc),
+      profileIdc: this._profileIdc,
+      level: hLevel(this._levelIdc),
+      levelIdc: this._levelIdc,
+    } as const;
+  }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264, h265, h266} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -38,6 +38,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(h266.H266Info);
     expect(info.codecName).toBe('h266');
     expect((info as h266.H266Info).levelIdc).toBe(83);
+  });
+
+  it('dispatches lvc strings to LcevcInfo', () => {
+    const info = codecInfoFactory('lvc1.vprf0.vlev4');
+    expect(info).toBeInstanceOf(lcevc.LcevcInfo);
+    expect(info.codecName).toBe('lcevc');
+    expect((info as lcevc.LcevcInfo).levelIdc).toBe(4);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,14 @@ import {Av1Info} from "./codec/av1";
 import {H264Info} from "./codec/h264";
 import {H265Info} from "./codec/h265";
 import {H266Info} from "./codec/h266";
+import {LcevcInfo} from "./codec/lcevc";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
 export * as h264 from "./codec/h264";
 export * as h265 from "./codec/h265";
 export * as h266 from "./codec/h266";
+export * as lcevc from "./codec/lcevc";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -28,6 +30,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('vvc') || codecString.startsWith('vvi')) {
     return H266Info.fromString(codecString);
+  }
+  if (codecString.startsWith('lvc')) {
+    return LcevcInfo.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Adds `lvc1` (MPEG-5 Part 2 / ISO/IEC 23094-2) codec strings: `lvc1.vprf<profile>.vlev<level>` (e.g. `lvc1.vprf0.vlev4`). Key-value format, case-insensitive and order-independent keys; profile decodes to Main / Main 4:4:4. Format verified against paulhiggs/codec-string. 18 tests; full suite 170 passing.

`feat:` → minor bump (0.4.0).