### PR TITLE
feat: add APV codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | H.265 (HEVC) | ✅ | ✅  |
 | H.266 (VVC) | ✅ | ✅   |
 | LCEVC | ✅ | ✅          |
+| APV   | ✅ | ✅          |
 
 ## Install
 
@@ -92,8 +93,9 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`) and returns a `Vp8Info`, `Vp9Info`,
-  `Av1Info`, `H264Info`, `H265Info`, `H266Info`, or `LcevcInfo`. Throws `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`, `apv1`) and returns a `Vp8Info`,
+  `Vp9Info`, `Av1Info`, `H264Info`, `H265Info`, `H266Info`, `LcevcInfo`, or `ApvInfo`. Throws
+  `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
@@ -103,6 +105,8 @@ console.log(info.toString());                // 'avc1.640028'
   and output-layer-set (`O`) fields are preserved verbatim for round-tripping.
 - `lcevc` — namespace exporting `LcevcInfo` and `LcevcProfile` (MPEG-5 Part 2 enhancement codec,
   `lvc1.vprf<profile>.vlev<level>`).
+- `apv` — namespace exporting `ApvInfo` (Advanced Professional Video,
+  `apv1.apvf<profile>.apvl<level>.apvb<band>`).
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/apv/apv-info.spec.ts
+++ b/src/codec/apv/apv-info.spec.ts
@@ -1,0 +1,86 @@
+import {ApvInfo} from "./apv-info";
+
+describe('ApvInfo', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'apv1.apvf44.apvl210.apvb3',
+      'apv1.apvf33.apvl90.apvb0',
+      'apv1.apvf44.apvl60.apvb2',
+    ])('parses and round-trips %s', (str) => {
+      expect(ApvInfo.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes the fields', () => {
+      const info = ApvInfo.fromString('apv1.apvf44.apvl210.apvb3');
+      expect(info.fourCC).toBe('apv1');
+      expect(info.profileIdc).toBe(44);
+      expect(info.levelIdc).toBe(210);
+      expect(info.bandIdc).toBe(3);
+    });
+
+    it('accepts case-insensitive keys and tolerates order', () => {
+      expect(ApvInfo.fromString('apv1.APVB3.apvl210.APVF44').toString())
+        .toBe('apv1.apvf44.apvl210.apvb3');
+    });
+  });
+
+  describe('human-readable', () => {
+    it('names the confirmed profile and derives the level', () => {
+      const hr = ApvInfo.fromString('apv1.apvf44.apvl210.apvb3').toHumanReadable();
+      expect(hr).toEqual({
+        fourCC: 'apv1',
+        profile: '422-12',
+        profileIdc: 44,
+        level: '7',
+        levelIdc: 210,
+        band: 3,
+      });
+    });
+
+    it('reports an unmapped profile as unknown while keeping the numeric idc', () => {
+      const hr = ApvInfo.fromString('apv1.apvf99.apvl90.apvb1').toHumanReadable();
+      expect(hr.profile).toBe('unknown');
+      expect(hr.profileIdc).toBe(99);
+      expect(hr.level).toBe('3');
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string from parts', () => {
+      const info = new ApvInfo();
+      info.profileIdc = 44;
+      info.levelIdc = 210;
+      info.bandIdc = 3;
+      expect(info.toString()).toBe('apv1.apvf44.apvl210.apvb3');
+    });
+
+    it('rejects out-of-range fields', () => {
+      expect(() => { new ApvInfo().profileIdc = 256; }).toThrow('apvf');
+      expect(() => { new ApvInfo().levelIdc = -1; }).toThrow('apvl');
+      expect(() => { new ApvInfo().bandIdc = 300; }).toThrow('apvb');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['apv1', 'apv1.apvf44', 'apv1.apvf44.apvl210'])(
+      'rejects a string missing a parameter: %s',
+      (str) => {
+        expect(() => ApvInfo.fromString(str)).toThrow('Invalid APV codec string');
+      },
+    );
+
+    it('rejects an unknown parameter key', () => {
+      expect(() => ApvInfo.fromString('apv1.apvf44.apvl210.apvb3.apvx1'))
+        .toThrow('Unknown APV parameter');
+    });
+
+    it('rejects a non-numeric value', () => {
+      expect(() => ApvInfo.fromString('apv1.apvfXX.apvl210.apvb3'))
+        .toThrow('Invalid APV parameter value');
+    });
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => ApvInfo.fromString('apv9.apvf44.apvl210.apvb3')).toThrow('Unknown codec');
+    });
+  });
+});

--- a/src/codec/apv/apv-info.ts
+++ b/src/codec/apv/apv-info.ts
@@ -1,0 +1,104 @@
+import {CodecInfo} from "../codec-info";
+import {APV_FOUR_CCS, ApvFourCC, hLevel, hProfile} from "./enums";
+
+function assertRange(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in the range ${min}-${max}`);
+  }
+  return value;
+}
+
+// APV codec information. Codec string: apv1.apvf<profile_idc>.apvl<level_idc>.apvb<band_idc>.
+export class ApvInfo extends CodecInfo {
+  codecName = 'apv';
+
+  private _fourCC: ApvFourCC = 'apv1';
+  private _profileIdc = 0;
+  private _levelIdc = 0;
+  private _bandIdc = 0;
+
+  get fourCC(): ApvFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: ApvFourCC) {
+    if (!APV_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid APV sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertRange(profileIdc, 0, 255, 'apvf (profile_idc)');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertRange(levelIdc, 0, 255, 'apvl (level_idc)');
+  }
+
+  get bandIdc(): number {
+    return this._bandIdc;
+  }
+
+  set bandIdc(bandIdc: number) {
+    this._bandIdc = assertRange(bandIdc, 0, 255, 'apvb (band_idc)');
+  }
+
+  static fromString(codecString: string): ApvInfo {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as ApvFourCC;
+    if (!APV_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    const info = new ApvInfo();
+    info.fourCC = fourCC;
+
+    const seen = {apvf: false, apvl: false, apvb: false};
+    for (const segment of parts.slice(1)) {
+      const key = segment.slice(0, 4).toLowerCase();
+      const value = segment.slice(4);
+      if (!/^\d+$/.test(value)) {
+        throw new Error(`Invalid APV parameter value: ${segment}`);
+      }
+      if (key === 'apvf') {
+        info.profileIdc = parseInt(value, 10);
+        seen.apvf = true;
+      } else if (key === 'apvl') {
+        info.levelIdc = parseInt(value, 10);
+        seen.apvl = true;
+      } else if (key === 'apvb') {
+        info.bandIdc = parseInt(value, 10);
+        seen.apvb = true;
+      } else {
+        throw new Error(`Unknown APV parameter: ${key}`);
+      }
+    }
+    if (!seen.apvf || !seen.apvl || !seen.apvb) {
+      throw new Error('Invalid APV codec string, expected apv1.apvf<profile>.apvl<level>.apvb<band>');
+    }
+    return info;
+  }
+
+  toString(): string {
+    return `${this._fourCC}.apvf${this._profileIdc}.apvl${this._levelIdc}.apvb${this._bandIdc}`;
+  }
+
+  toHumanReadable() {
+    return {
+      fourCC: this._fourCC,
+      profile: hProfile(this._profileIdc),
+      profileIdc: this._profileIdc,
+      level: hLevel(this._levelIdc),
+      levelIdc: this._levelIdc,
+      band: this._bandIdc,
+    } as const;
+  }
+}

--- a/src/codec/apv/enums.ts
+++ b/src/codec/apv/enums.ts
@@ -1,0 +1,21 @@
+// APV — Advanced Professional Video (OpenAPV / APVA), carried per ISO/IEC 14496-15. Codec string:
+//   apv1.apvf<profile_idc>.apvl<level_idc>.apvb<band_idc>
+// e.g. apv1.apvf44.apvl210.apvb3 = profile 422-12, level 7, band 3.
+
+export type ApvFourCC = 'apv1';
+export const APV_FOUR_CCS: readonly ApvFourCC[] = ['apv1'];
+
+// Only the profile_idc confirmed by the OpenAPV codec-string documentation is named here; other
+// values are reported by their numeric profile_idc via toHumanReadable().profileIdc.
+export function hProfile(profileIdc: number): string {
+  switch (profileIdc) {
+    case 44: return '422-12';
+    default: return 'unknown';
+  }
+}
+
+// The OpenAPV example maps level_idc 210 to level 7, i.e. level = level_idc / 30.
+export function hLevel(levelIdc: number): string {
+  if (levelIdc <= 0) return 'unknown';
+  return String(levelIdc / 30);
+}

--- a/src/codec/apv/index.ts
+++ b/src/codec/apv/index.ts
@@ -1,0 +1,3 @@
+export {APV_FOUR_CCS, hProfile, hLevel} from './enums';
+export type {ApvFourCC} from './enums';
+export * from './apv-info';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc, apv} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -45,6 +45,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(lcevc.LcevcInfo);
     expect(info.codecName).toBe('lcevc');
     expect((info as lcevc.LcevcInfo).levelIdc).toBe(4);
+  });
+
+  it('dispatches apv strings to ApvInfo', () => {
+    const info = codecInfoFactory('apv1.apvf44.apvl210.apvb3');
+    expect(info).toBeInstanceOf(apv.ApvInfo);
+    expect(info.codecName).toBe('apv');
+    expect((info as apv.ApvInfo).profileIdc).toBe(44);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {H264Info} from "./codec/h264";
 import {H265Info} from "./codec/h265";
 import {H266Info} from "./codec/h266";
 import {LcevcInfo} from "./codec/lcevc";
+import {ApvInfo} from "./codec/apv";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
@@ -11,6 +12,7 @@ export * as h264 from "./codec/h264";
 export * as h265 from "./codec/h265";
 export * as h266 from "./codec/h266";
 export * as lcevc from "./codec/lcevc";
+export * as apv from "./codec/apv";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -33,6 +35,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('lvc')) {
     return LcevcInfo.fromString(codecString);
+  }
+  if (codecString.startsWith('apv')) {
+    return ApvInfo.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Adds `apv1` (Advanced Professional Video / OpenAPV) codec strings: `apv1.apvf<profile>.apvl<level>.apvb<band>` (e.g. `apv1.apvf44.apvl210.apvb3`). Structure verified against the OpenAPV apv_isobmff doc. Profile/level/band exposed as raw numbers; the confirmed `44 → 422-12` profile name and `level = idc/30` are decoded in `toHumanReadable()`, other profile names reported by numeric idc. 16 tests; full suite 186 passing.

`feat:` → minor bump (0.5.0).