### PR TITLE
feat: add EVC codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | H.266 (VVC) | ✅ | ✅   |
 | LCEVC | ✅ | ✅          |
 | APV   | ✅ | ✅          |
+| EVC   | ✅ | ✅          |
 
 ## Install
 
@@ -93,9 +94,9 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`, `apv1`) and returns a `Vp8Info`,
-  `Vp9Info`, `Av1Info`, `H264Info`, `H265Info`, `H266Info`, `LcevcInfo`, or `ApvInfo`. Throws
-  `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`, `apv1`, `evc1`) and returns a
+  `Vp8Info`, `Vp9Info`, `Av1Info`, `H264Info`, `H265Info`, `H266Info`, `LcevcInfo`, `ApvInfo`, or
+  `EvcInfo`. Throws `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
@@ -107,6 +108,9 @@ console.log(info.toString());                // 'avc1.640028'
   `lvc1.vprf<profile>.vlev<level>`).
 - `apv` — namespace exporting `ApvInfo` (Advanced Professional Video,
   `apv1.apvf<profile>.apvl<level>.apvb<band>`).
+- `evc` — namespace exporting `EvcInfo`, `EvcProfile` (MPEG-5 Part 1,
+  `evc1.vprf<profile>.vlev<level>`). Mandatory profile/level are decoded; the optional toolset,
+  bit-depth and colour parameters are preserved verbatim.
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/evc/enums.ts
+++ b/src/codec/evc/enums.ts
@@ -1,0 +1,35 @@
+// EVC / MPEG-5 Part 1 (ISO/IEC 23094-1), carried per ISO/IEC 14496-15. Codec string:
+//   evc1.vprf<profile>.vlev<level>[.vtoh<hex>.vtol<hex>.vbit.vcss.vcpr.vtrc.vmac.vfrf.vfpq.vpci.vsar]
+// e.g. evc1.vprf1.vlev51 (minimal) or the full colour-signalled form. vprf/vlev are mandatory;
+// the rest are optional and preserved verbatim.
+
+export type EvcFourCC = 'evc1';
+export const EVC_FOUR_CCS: readonly EvcFourCC[] = ['evc1'];
+
+export enum EvcProfile {
+  BASELINE = 0,
+  MAIN = 1,
+  BASELINE_STILL_PICTURE = 2,
+  MAIN_STILL_PICTURE = 3,
+}
+
+// Recognised optional parameter keys, in the canonical order they are emitted.
+export const EVC_OPTIONAL_KEYS: readonly string[] = [
+  'vtoh', 'vtol', 'vbit', 'vcss', 'vcpr', 'vtrc', 'vmac', 'vfrf', 'vfpq', 'vpci', 'vsar',
+];
+
+export function hProfile(profileIdc: number): string {
+  switch (profileIdc) {
+    case EvcProfile.BASELINE: return 'Baseline';
+    case EvcProfile.MAIN: return 'Main';
+    case EvcProfile.BASELINE_STILL_PICTURE: return 'Baseline Still Picture';
+    case EvcProfile.MAIN_STILL_PICTURE: return 'Main Still Picture';
+    default: return 'unknown';
+  }
+}
+
+// EVC levels follow the AVC-style level_idc / 10 (e.g. 51 -> 5.1, 20 -> 2.0).
+export function hLevel(levelIdc: number): string {
+  if (levelIdc <= 0) return 'unknown';
+  return `${Math.floor(levelIdc / 10)}.${levelIdc % 10}`;
+}

--- a/src/codec/evc/evc-info.spec.ts
+++ b/src/codec/evc/evc-info.spec.ts
@@ -1,0 +1,114 @@
+import {EvcInfo} from "./evc-info";
+import {EvcProfile} from "./enums";
+
+const FULL = 'evc1.vprf1.vlev51.vtoh1fffff.vtol000000.vbit00.vcss420.vcpr01.vtrc01.vmac01.vfrf1.vsar01';
+
+describe('EvcInfo', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'evc1.vprf0.vlev20',
+      'evc1.vprf1.vlev51',
+      'evc1.vprf3.vlev62',
+      FULL,
+    ])('parses and round-trips %s', (str) => {
+      expect(EvcInfo.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes the mandatory fields and preserves the optional ones', () => {
+      const info = EvcInfo.fromString(FULL);
+      expect(info.fourCC).toBe('evc1');
+      expect(info.profileIdc).toBe(EvcProfile.MAIN);
+      expect(info.levelIdc).toBe(51);
+      expect(info.optionalParams).toEqual([
+        {key: 'vtoh', value: '1fffff'},
+        {key: 'vtol', value: '000000'},
+        {key: 'vbit', value: '00'},
+        {key: 'vcss', value: '420'},
+        {key: 'vcpr', value: '01'},
+        {key: 'vtrc', value: '01'},
+        {key: 'vmac', value: '01'},
+        {key: 'vfrf', value: '1'},
+        {key: 'vsar', value: '01'},
+      ]);
+    });
+
+    it('lowercases parameter keys', () => {
+      expect(EvcInfo.fromString('evc1.VPRF1.VLEV51').toString()).toBe('evc1.vprf1.vlev51');
+    });
+  });
+
+  describe('human-readable', () => {
+    it.each([
+      ['evc1.vprf0.vlev20', 'Baseline'],
+      ['evc1.vprf1.vlev51', 'Main'],
+      ['evc1.vprf2.vlev20', 'Baseline Still Picture'],
+      ['evc1.vprf3.vlev20', 'Main Still Picture'],
+    ])('%s -> %s', (str, profile) => {
+      expect(EvcInfo.fromString(str).toHumanReadable().profile).toBe(profile);
+    });
+
+    it.each([
+      ['evc1.vprf1.vlev20', '2.0'],
+      ['evc1.vprf1.vlev51', '5.1'],
+      ['evc1.vprf1.vlev62', '6.2'],
+    ])('%s -> level %s', (str, level) => {
+      expect(EvcInfo.fromString(str).toHumanReadable().level).toBe(level);
+    });
+
+    it('reports every field', () => {
+      expect(EvcInfo.fromString('evc1.vprf1.vlev51.vcpr09').toHumanReadable()).toEqual({
+        fourCC: 'evc1',
+        profile: 'Main',
+        profileIdc: 1,
+        level: '5.1',
+        levelIdc: 51,
+        optionalParams: 'vcpr09',
+      });
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a minimal codec string', () => {
+      const info = new EvcInfo();
+      info.profileIdc = EvcProfile.MAIN;
+      info.levelIdc = 51;
+      expect(info.toString()).toBe('evc1.vprf1.vlev51');
+    });
+
+    it('assembles a codec string with optional params', () => {
+      const info = new EvcInfo();
+      info.profileIdc = 1;
+      info.levelIdc = 51;
+      info.optionalParams = [{key: 'vbit', value: '00'}, {key: 'vcss', value: '420'}];
+      expect(info.toString()).toBe('evc1.vprf1.vlev51.vbit00.vcss420');
+    });
+
+    it('rejects out-of-range fields and unknown optional keys', () => {
+      expect(() => { new EvcInfo().profileIdc = 256; }).toThrow('vprf');
+      expect(() => { new EvcInfo().levelIdc = -1; }).toThrow('vlev');
+      expect(() => { new EvcInfo().optionalParams = [{key: 'vxxx', value: '1'}]; })
+        .toThrow('Unknown EVC parameter');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['evc1', 'evc1.vprf1', 'evc1.vlev51'])(
+      'rejects a string missing a mandatory parameter: %s',
+      (str) => {
+        expect(() => EvcInfo.fromString(str)).toThrow('Invalid EVC codec string');
+      },
+    );
+
+    it('rejects an unknown parameter key', () => {
+      expect(() => EvcInfo.fromString('evc1.vprf1.vlev51.vxxx1')).toThrow('Unknown EVC parameter');
+    });
+
+    it('rejects a non-hex toolset value', () => {
+      expect(() => EvcInfo.fromString('evc1.vprf1.vlev51.vtohZZ')).toThrow('Invalid EVC parameter value');
+    });
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => EvcInfo.fromString('evc9.vprf1.vlev51')).toThrow('Unknown codec');
+    });
+  });
+});

--- a/src/codec/evc/evc-info.ts
+++ b/src/codec/evc/evc-info.ts
@@ -1,0 +1,130 @@
+import {CodecInfo} from "../codec-info";
+import {EVC_FOUR_CCS, EVC_OPTIONAL_KEYS, EvcFourCC, hLevel, hProfile} from "./enums";
+
+function assertRange(value: number, min: number, max: number, name: string): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in the range ${min}-${max}`);
+  }
+  return value;
+}
+
+interface EvcOptionalParam {
+  key: string;
+  value: string;
+}
+
+// vtoh/vtol are hex; the remaining optional parameters are decimal.
+function validateOptionalValue(key: string, value: string): void {
+  const pattern = key === 'vtoh' || key === 'vtol' ? /^[0-9a-fA-F]+$/ : /^\d+$/;
+  if (!pattern.test(value)) {
+    throw new Error(`Invalid EVC parameter value: ${key}${value}`);
+  }
+}
+
+// EVC codec information.
+// Codec string: evc1.vprf<profile>.vlev<level>[.<optional key/value params>].
+export class EvcInfo extends CodecInfo {
+  codecName = 'evc';
+
+  private _fourCC: EvcFourCC = 'evc1';
+  private _profileIdc = 0;
+  private _levelIdc = 0;
+  private _optionalParams: EvcOptionalParam[] = [];
+
+  get fourCC(): EvcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: EvcFourCC) {
+    if (!EVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid EVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  get profileIdc(): number {
+    return this._profileIdc;
+  }
+
+  set profileIdc(profileIdc: number) {
+    this._profileIdc = assertRange(profileIdc, 0, 255, 'vprf (profile_idc)');
+  }
+
+  get levelIdc(): number {
+    return this._levelIdc;
+  }
+
+  set levelIdc(levelIdc: number) {
+    this._levelIdc = assertRange(levelIdc, 0, 255, 'vlev (level_idc)');
+  }
+
+  // Optional colour / toolset / bit-depth parameters, preserved verbatim.
+  get optionalParams(): EvcOptionalParam[] {
+    return this._optionalParams.map((param) => ({...param}));
+  }
+
+  set optionalParams(optionalParams: EvcOptionalParam[]) {
+    optionalParams.forEach(({key, value}) => {
+      if (!EVC_OPTIONAL_KEYS.includes(key)) {
+        throw new Error(`Unknown EVC parameter: ${key}`);
+      }
+      validateOptionalValue(key, value);
+    });
+    this._optionalParams = optionalParams.map((param) => ({...param}));
+  }
+
+  static fromString(codecString: string): EvcInfo {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as EvcFourCC;
+    if (!EVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    const info = new EvcInfo();
+    info.fourCC = fourCC;
+
+    let hasProfile = false;
+    let hasLevel = false;
+    const optionalParams: EvcOptionalParam[] = [];
+    for (const segment of parts.slice(1)) {
+      const key = segment.slice(0, 4).toLowerCase();
+      const value = segment.slice(4);
+      if (key === 'vprf') {
+        if (!/^\d+$/.test(value)) throw new Error(`Invalid EVC parameter value: ${segment}`);
+        info.profileIdc = parseInt(value, 10);
+        hasProfile = true;
+      } else if (key === 'vlev') {
+        if (!/^\d+$/.test(value)) throw new Error(`Invalid EVC parameter value: ${segment}`);
+        info.levelIdc = parseInt(value, 10);
+        hasLevel = true;
+      } else if (EVC_OPTIONAL_KEYS.includes(key)) {
+        validateOptionalValue(key, value);
+        optionalParams.push({key, value});
+      } else {
+        throw new Error(`Unknown EVC parameter: ${key}`);
+      }
+    }
+    if (!hasProfile || !hasLevel) {
+      throw new Error('Invalid EVC codec string, expected evc1.vprf<profile>.vlev<level>');
+    }
+    info._optionalParams = optionalParams;
+    return info;
+  }
+
+  toString(): string {
+    const optional = this._optionalParams.map(({key, value}) => `.${key}${value}`).join('');
+    return `${this._fourCC}.vprf${this._profileIdc}.vlev${this._levelIdc}${optional}`;
+  }
+
+  toHumanReadable() {
+    return {
+      fourCC: this._fourCC,
+      profile: hProfile(this._profileIdc),
+      profileIdc: this._profileIdc,
+      level: hLevel(this._levelIdc),
+      levelIdc: this._levelIdc,
+      optionalParams: this._optionalParams.length
+        ? this._optionalParams.map(({key, value}) => key + value).join('.')
+        : 'none',
+    } as const;
+  }
+}

--- a/src/codec/evc/index.ts
+++ b/src/codec/evc/index.ts
@@ -1,0 +1,3 @@
+export {EvcProfile, EVC_FOUR_CCS, EVC_OPTIONAL_KEYS, hProfile, hLevel} from './enums';
+export type {EvcFourCC} from './enums';
+export * from './evc-info';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc, apv} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc, apv, evc} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -52,6 +52,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(apv.ApvInfo);
     expect(info.codecName).toBe('apv');
     expect((info as apv.ApvInfo).profileIdc).toBe(44);
+  });
+
+  it('dispatches evc strings to EvcInfo', () => {
+    const info = codecInfoFactory('evc1.vprf1.vlev51');
+    expect(info).toBeInstanceOf(evc.EvcInfo);
+    expect(info.codecName).toBe('evc');
+    expect((info as evc.EvcInfo).levelIdc).toBe(51);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {H265Info} from "./codec/h265";
 import {H266Info} from "./codec/h266";
 import {LcevcInfo} from "./codec/lcevc";
 import {ApvInfo} from "./codec/apv";
+import {EvcInfo} from "./codec/evc";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
@@ -13,6 +14,7 @@ export * as h265 from "./codec/h265";
 export * as h266 from "./codec/h266";
 export * as lcevc from "./codec/lcevc";
 export * as apv from "./codec/apv";
+export * as evc from "./codec/evc";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -38,6 +40,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('apv')) {
     return ApvInfo.fromString(codecString);
+  }
+  if (codecString.startsWith('evc')) {
+    return EvcInfo.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Adds `evc1` (MPEG-5 Part 1 / ISO/IEC 23094-1) codec strings: mandatory `evc1.vprf<profile>.vlev<level>` (e.g. `evc1.vprf1.vlev51`) plus the optional toolset/bit-depth/chroma/colour/aspect parameters. Profile and level (idc/10) decoded; optional params validated and preserved verbatim. Format verified against paulhiggs/codec-string. 24 tests; full suite 210 passing.

`feat:` → minor bump (0.6.0). This completes the LCEVC/APV/EVC batch.