### PR TITLE
feat: add L-HEVC (Layered HEVC) codec string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Useful for reading codec parameters out of a `codecs=` string, checking support 
 | LCEVC | ✅ | ✅          |
 | APV   | ✅ | ✅          |
 | EVC   | ✅ | ✅          |
+| L-HEVC | ✅ | ✅         |
 
 ## Install
 
@@ -94,9 +95,9 @@ console.log(info.toString());                // 'avc1.640028'
 ## API
 
 - `codecInfoFactory(codecString)` — dispatches by prefix (`vp08`/`vp8`, `vp09`/`vp9`, `av01`,
-  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`, `apv1`, `evc1`) and returns a
-  `Vp8Info`, `Vp9Info`, `Av1Info`, `H264Info`, `H265Info`, `H266Info`, `LcevcInfo`, `ApvInfo`, or
-  `EvcInfo`. Throws `Unknown codec` for anything else.
+  `avc1`/`avc2`/`avc3`/`avc4`, `hev1`/`hvc1`, `vvc1`/`vvi1`, `lvc1`, `apv1`, `evc1`, `lhv1`/`lhe1`) and
+  returns a `Vp8Info`, `Vp9Info`, `Av1Info`, `H264Info`, `H265Info`, `H266Info`, `LcevcInfo`,
+  `ApvInfo`, `EvcInfo`, or `LhevcInfo`. Throws `Unknown codec` for anything else.
 - `vpx` — namespace exporting `Vp8Info`, `Vp9Info`, `vpxInfoFactory`, and the `Vpx*` enums.
 - `av1` — namespace exporting `Av1Info` and the `Av1*` enums.
 - `h264` — namespace exporting `H264Info`, `AvcProfileIdc`, and the `hProfile`/`hLevel` helpers.
@@ -111,6 +112,9 @@ console.log(info.toString());                // 'avc1.640028'
 - `evc` — namespace exporting `EvcInfo`, `EvcProfile` (MPEG-5 Part 1,
   `evc1.vprf<profile>.vlev<level>`). Mandatory profile/level are decoded; the optional toolset,
   bit-depth and colour parameters are preserved verbatim.
+- `lhevc` — namespace exporting `LhevcInfo` (Layered HEVC — SHVC / MV-HEVC, `lhv1`/`lhe1`). The HEVC
+  profile-tier-level is exposed via `.ptl` (an `H265Info`); the optional scalability field is preserved
+  verbatim in `.scalability`.
 - Shared ISO/IEC 23001-8:2016 colour enums (`ColourPrimaries`, `TransferCharacteristics`,
   `MatrixCoefficients`, `VideoFullRangeFlag`) are re-exported from both namespaces.
 

--- a/src/codec/lhevc/enums.ts
+++ b/src/codec/lhevc/enums.ts
@@ -1,0 +1,8 @@
+// L-HEVC / Layered HEVC (SHVC, MV-HEVC), carried per ISO/IEC 14496-15. Codec string:
+//   <fourCC>.<HEVC profile-tier-level>[.S<scalability mask>]
+// e.g. lhv1.2.4.L120.B0 (same profile-tier-level syntax as hvc1), optionally followed by a
+// scalability field ".S<XX>". The PTL part is decoded via the HEVC parser; the scalability field
+// is preserved verbatim (its byte encoding is not freely specified).
+
+export type LhevcFourCC = 'lhv1' | 'lhe1';
+export const LHEVC_FOUR_CCS: readonly LhevcFourCC[] = ['lhv1', 'lhe1'];

--- a/src/codec/lhevc/index.ts
+++ b/src/codec/lhevc/index.ts
@@ -1,0 +1,3 @@
+export {LHEVC_FOUR_CCS} from './enums';
+export type {LhevcFourCC} from './enums';
+export * from './lhevc-info';

--- a/src/codec/lhevc/lhevc-info.spec.ts
+++ b/src/codec/lhevc/lhevc-info.spec.ts
@@ -1,0 +1,86 @@
+import {LhevcInfo} from "./lhevc-info";
+
+describe('LhevcInfo', () => {
+  describe('parse / round-trip', () => {
+    it.each([
+      'lhv1.2.4.L120.B0',
+      'lhe1.1.6.L93.B0',
+      'lhv1.A4.4.H120',
+      'lhv1.2.4.L120.B0.SC01',
+    ])('parses and round-trips %s', (str) => {
+      expect(LhevcInfo.fromString(str).toString()).toBe(str);
+    });
+
+    it('decodes the HEVC profile-tier-level and preserves the scalability field', () => {
+      const info = LhevcInfo.fromString('lhv1.2.4.L120.B0.SC01');
+      expect(info.fourCC).toBe('lhv1');
+      expect(info.ptl.profileIdc).toBe(2);
+      expect(info.ptl.tierFlag).toBe(0);
+      expect(info.ptl.levelIdc).toBe(120);
+      expect(info.ptl.constraintFlags).toEqual([0xB0]);
+      expect(info.scalability).toEqual(['SC01']);
+    });
+
+    it('handles the in-band lhe1 sample entry', () => {
+      expect(LhevcInfo.fromString('lhe1.1.6.L93.B0').fourCC).toBe('lhe1');
+    });
+  });
+
+  describe('human-readable', () => {
+    it('reports the PTL fields and scalability', () => {
+      expect(LhevcInfo.fromString('lhv1.2.4.L120.B0').toHumanReadable()).toEqual({
+        fourCC: 'lhv1',
+        profile: 'Main 10',
+        profileIdc: 2,
+        tier: 'main',
+        level: '4.0',
+        levelIdc: 120,
+        scalability: 'none',
+      });
+    });
+  });
+
+  describe('build', () => {
+    it('assembles a codec string via the reused HEVC PTL', () => {
+      const info = new LhevcInfo();
+      info.fourCC = 'lhv1';
+      info.ptl.profileIdc = 2;
+      info.ptl.compatibilityFlags = 0x4;
+      info.ptl.levelIdc = 120;
+      info.ptl.constraintFlags = [0xB0];
+      expect(info.toString()).toBe('lhv1.2.4.L120.B0');
+    });
+
+    it('appends a scalability field', () => {
+      const info = new LhevcInfo();
+      info.ptl.profileIdc = 1;
+      info.ptl.compatibilityFlags = 0x6;
+      info.ptl.levelIdc = 93;
+      info.ptl.constraintFlags = [0xB0];
+      info.scalability = ['SC01'];
+      expect(info.toString()).toBe('lhv1.1.6.L93.B0.SC01');
+    });
+
+    it('rejects a scalability field that does not start with S', () => {
+      expect(() => { new LhevcInfo().scalability = ['C01']; })
+        .toThrow('must start with "S"');
+    });
+  });
+
+  describe('invalid input', () => {
+    it.each(['lhv1', 'lhv1.2'])(
+      'rejects a string without a full profile-tier-level: %s',
+      (str) => {
+        expect(() => LhevcInfo.fromString(str)).toThrow('Invalid L-HEVC codec string');
+      },
+    );
+
+    it('propagates an invalid profile-tier-level error', () => {
+      expect(() => LhevcInfo.fromString('lhv1.2.4.X120')).toThrow(/Invalid HEVC/);
+    });
+
+    it('rejects an unknown 4CC', () => {
+      expect(() => LhevcInfo.fromString('lhv9.2.4.L120')).toThrow('Unknown codec');
+    });
+  });
+});

--- a/src/codec/lhevc/lhevc-info.ts
+++ b/src/codec/lhevc/lhevc-info.ts
@@ -1,0 +1,89 @@
+import {CodecInfo} from "../codec-info";
+import {H265Info} from "../h265";
+import {LHEVC_FOUR_CCS, LhevcFourCC} from "./enums";
+
+// L-HEVC codec information. The profile-tier-level is the HEVC one (reused from H265Info); the
+// optional trailing scalability field (".S<mask>") is preserved verbatim.
+export class LhevcInfo extends CodecInfo {
+  codecName = 'lhevc';
+
+  private _fourCC: LhevcFourCC = 'lhv1';
+  private _ptl = new H265Info();
+  private _scalability: string[] = [];
+
+  get fourCC(): LhevcFourCC {
+    return this._fourCC;
+  }
+
+  set fourCC(fourCC: LhevcFourCC) {
+    if (!LHEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error(`Invalid L-HEVC sample entry: ${fourCC}`);
+    }
+    this._fourCC = fourCC;
+  }
+
+  // The HEVC profile-tier-level (its internal 4CC is unused; L-HEVC tracks its own fourCC).
+  get ptl(): H265Info {
+    return this._ptl;
+  }
+
+  // Trailing scalability field, e.g. ["SC01"], preserved verbatim.
+  get scalability(): string[] {
+    return [...this._scalability];
+  }
+
+  set scalability(scalability: string[]) {
+    if (scalability.length > 0 && !/^S/i.test(scalability[0])) {
+      throw new Error('The L-HEVC scalability field must start with "S"');
+    }
+    scalability.forEach((segment) => {
+      if (!segment) {
+        throw new Error('L-HEVC scalability segments must not be empty');
+      }
+    });
+    this._scalability = [...scalability];
+  }
+
+  static fromString(codecString: string): LhevcInfo {
+    const parts = codecString.split('.');
+    const fourCC = parts[0] as LhevcFourCC;
+    if (!LHEVC_FOUR_CCS.includes(fourCC)) {
+      throw new Error('Unknown codec');
+    }
+    const rest = parts.slice(1);
+    // The scalability field (and anything after it) starts with "S"; HEVC PTL segments never do.
+    const scalabilityStart = rest.findIndex((segment) => /^S/i.test(segment));
+    const ptlSegments = scalabilityStart === -1 ? rest : rest.slice(0, scalabilityStart);
+    const scalability = scalabilityStart === -1 ? [] : rest.slice(scalabilityStart);
+    if (ptlSegments.length < 3) {
+      throw new Error('Invalid L-HEVC codec string, expected <fourCC>.<profile-tier-level>[.S<scalability>]');
+    }
+
+    const info = new LhevcInfo();
+    info.fourCC = fourCC;
+    // Reuse the HEVC profile-tier-level parser (with its validation) via a throwaway hvc1 string.
+    info._ptl = H265Info.fromString(`hvc1.${ptlSegments.join('.')}`);
+    info.scalability = scalability;
+    return info;
+  }
+
+  toString(): string {
+    const ptlString = this._ptl.toString();
+    const ptlParams = ptlString.slice(ptlString.indexOf('.') + 1);
+    const scalability = this._scalability.length ? `.${this._scalability.join('.')}` : '';
+    return `${this._fourCC}.${ptlParams}${scalability}`;
+  }
+
+  toHumanReadable() {
+    const ptl = this._ptl.toHumanReadable();
+    return {
+      fourCC: this._fourCC,
+      profile: ptl.profile,
+      profileIdc: ptl.profileIdc,
+      tier: ptl.tier,
+      level: ptl.level,
+      levelIdc: ptl.levelIdc,
+      scalability: this._scalability.length ? this._scalability.join('.') : 'none',
+    } as const;
+  }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc, apv, evc} from './index';
+import {codecInfoFactory, version, vpx, av1, h264, h265, h266, lcevc, apv, evc, lhevc} from './index';
 
 describe('codecInfoFactory', () => {
   it('dispatches vp8 strings to Vp8Info', () => {
@@ -59,6 +59,13 @@ describe('codecInfoFactory', () => {
     expect(info).toBeInstanceOf(evc.EvcInfo);
     expect(info.codecName).toBe('evc');
     expect((info as evc.EvcInfo).levelIdc).toBe(51);
+  });
+
+  it('dispatches lhv/lhe strings to LhevcInfo', () => {
+    const info = codecInfoFactory('lhv1.2.4.L120.B0');
+    expect(info).toBeInstanceOf(lhevc.LhevcInfo);
+    expect(info.codecName).toBe('lhevc');
+    expect((info as lhevc.LhevcInfo).ptl.levelIdc).toBe(120);
   });
 
   it('throws on an unknown codec', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {H266Info} from "./codec/h266";
 import {LcevcInfo} from "./codec/lcevc";
 import {ApvInfo} from "./codec/apv";
 import {EvcInfo} from "./codec/evc";
+import {LhevcInfo} from "./codec/lhevc";
 
 export * as vpx from "./codec/vpx";
 export * as av1 from "./codec/av1";
@@ -15,6 +16,7 @@ export * as h266 from "./codec/h266";
 export * as lcevc from "./codec/lcevc";
 export * as apv from "./codec/apv";
 export * as evc from "./codec/evc";
+export * as lhevc from "./codec/lhevc";
 export * from './codec/codec-info';
 
 export const version = '__lib_version__'; // Version will be injected on the build
@@ -43,6 +45,9 @@ export const codecInfoFactory = (codecString: string) => {
   }
   if (codecString.startsWith('evc')) {
     return EvcInfo.fromString(codecString);
+  }
+  if (codecString.startsWith('lhv') || codecString.startsWith('lhe')) {
+    return LhevcInfo.fromString(codecString);
   }
   throw new Error('Unknown codec');
 }


### PR DESCRIPTION
Adds `lhv1`/`lhe1` (Layered HEVC — SHVC / MV-HEVC, ISO/IEC 14496-15) codec strings, e.g. `lhv1.2.4.L120.B0`.

**Format verification:** the profile-tier-level part is the HEVC PTL syntax (confirmed — ISO 14496-15 reuses the HEVC PTL value), decoded by reusing the tested `H265Info` (exposed via `.ptl`). The optional trailing scalability field `.S<mask>` is real but its byte encoding is not freely specified (ISO 14496-15 is paywalled; paulhiggs/codec-string only labels lhv1 without parsing), so it is **preserved verbatim** in `.scalability` rather than guessed.

15 tests; full suite 225 passing. `feat:` → minor bump (0.7.0).